### PR TITLE
♻️ [Refactor] pcapsule 글사진 API 로직 수정 및 이미지 업로드 함수 구현

### DIFF
--- a/config/multer.js
+++ b/config/multer.js
@@ -4,9 +4,12 @@ import path from "path";
 // const AWS = require('./aws'); // aws.js 파일 가져오기
 import AWS from "./aws";
 
+// 코드 중복 방지
+const s3Client = new AWS.S3();
+
 const upload = multer({
 	storage: multerS3({
-		s3: new AWS.S3(),
+		s3: s3Client,
 		bucket: process.env.S3_BUCKET_NAME,
 		acl: "public-read-write",
 		contentType: multerS3.AUTO_CONTENT_TYPE,
@@ -22,7 +25,7 @@ const allowedExtensions = [".png", ".jpg", ".jpeg", ".bmp"];
 
 const imageupload = multer({
 	storage: multerS3({
-		s3: new AWS.S3(),
+		s3: s3Client,
 		bucket: process.env.S3_BUCKET_NAME,
 		acl: "public-read-write",
 		key(req, file, callback) {
@@ -35,6 +38,39 @@ const imageupload = multer({
 		},
 	}),
 });
+
+export const uploadImageToS3 = async (base64Image) => {
+	// 이미지 타입 추출 (예: 'image/png')
+	const imageType = base64Image.match(/data:(.*);base64,/)[1];
+
+	// base64 인코딩 부분만 추출
+	// base64 데이터의 헤더 부분을 제거한 후 Buffer.from 함수에 전달
+	const base64Data = base64Image.replace(/^data:image\/\w+;base64,/, "");
+
+	const buffer = Buffer.from(base64Data, "base64");
+
+	// 확장자 추출 (예: 'png')
+	const extension = imageType.split("/")[1];
+
+	const fileName = `images/${Date.now().toString()}.${extension}`; // 파일명 설정
+
+	const data = {
+		Bucket: process.env.S3_BUCKET_NAME,
+		Key: fileName,
+		Body: buffer,
+		ContentEncoding: "base64",
+		ContentType: imageType,
+		ACL: "public-read",
+	};
+
+	try {
+		const response = await s3Client.upload(data).promise();
+		// console.log("esponse.Location: ", response.Location);
+		return response.Location; // 업로드된 이미지의 URL을 반환
+	} catch (error) {
+		console.log("uploadImageToS3 err : ", error);
+	}
+};
 
 // export default imageupload;
 export default upload;

--- a/src/app/Pcapsule/pcapsuleProvider.js
+++ b/src/app/Pcapsule/pcapsuleProvider.js
@@ -4,8 +4,6 @@ import { status } from "../../../config/responseStatus.js";
 
 import {
 	savePassword_d,
-	saveTextImage,
-	saveVoice,
 	updateOpenedStatus_d,
 	checkCapsuleNum_d,
 } from "./pcapsuleDao.js";

--- a/src/app/Pcapsule/pcapsuleService.js
+++ b/src/app/Pcapsule/pcapsuleService.js
@@ -2,7 +2,7 @@
 import { pool } from "../../../config/dbConfig.js";
 import { BaseError } from "../../../config/error.js";
 import { status } from "../../../config/responseStatus.js";
-import { createCapsuleNum_p, createContent_p } from "./pcapsuleProvider.js";
+import { createCapsuleNum_p } from "./pcapsuleProvider.js";
 import {
 	checkCapsuleNum_d,
 	insertPcapsule_d,
@@ -16,6 +16,8 @@ import {
 	saveVoice,
 	updateCapsuleStatus,
 } from "./pcapsuleDao.js";
+
+import { uploadImageToS3 } from "../../../config/multer.js";
 
 // 캡슐 생성
 export const createPcs_s = async (body, nickname) => {
@@ -104,11 +106,13 @@ export const addTextImage_s = async (
 					align_type,
 				);
 			} else if (value.type === "image") {
+				const imageUrl = await uploadImageToS3(value.content);
+
 				textImageId = await saveTextImage(
 					connection,
 					pcapsuleId,
 					null,
-					value.content, // 이미지인 경우 값 저장
+					imageUrl,
 					align_type,
 				);
 			}

--- a/swagger/rememorySwagger.yaml
+++ b/swagger/rememorySwagger.yaml
@@ -438,7 +438,7 @@ paths:
                 description: Capsule number
                 example: "testMember1_74177"
               pcapsule_password:
-                type: integer
+                type: string
                 description: Password for the pcapsule
                 example: 123456
       responses:

--- a/swagger/rememorySwagger.yaml
+++ b/swagger/rememorySwagger.yaml
@@ -251,8 +251,15 @@ paths:
                 example:
                   [
                     { type: "text", content: "안녕" },
-                    { type: "image", content: "이미지 URL1" },
-                    { type: "image", content: "이미지 URL2" },
+                    {
+                      type: "image",
+                      content: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMA…kakDsHxpPTEAbA/7800saP21M9FC5t1EGAAAAAElFTkSuQmCC",
+                    },
+                    {
+                      type: "image",
+                      content: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMA…kakDsHxpPTEAbA/7800saP21M9FC5t1EGAAAAAElFTkSuQmCC",
+                    },
+
                     { type: "text", content: "이 사진 기억나?" },
                   ]
               align_type:
@@ -287,11 +294,11 @@ paths:
                             { type: "text", content: "안녕" },
                             {
                               type: "image",
-                              content: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMA…kakDsHxpPTEAbA/7800saP21M9FC5t1EGAAAAAElFTkSuQmCC",
+                              content: "https://re-memory-bucket.s3.ap-northeast-2.amazonaws.com/images/example.jpg",
                             },
                             {
                               type: "image",
-                              content: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMA…kakDsHxpPTEAbA/7800saP21M9FC5t1EGAAAAAElFTkSuQmCC",
+                              content: "https://re-memory-bucket.s3.ap-northeast-2.amazonaws.com/images/example2.png",
                             },
                             { type: "text", content: "이 사진 기억나?" },
                           ],
@@ -1292,7 +1299,6 @@ paths:
                   message:
                     type: string
                     example: "Internal Server Error. 관리자에게 문의하세요."
-
 
   # 추가 rcapsule 조회, 상세조회
   /rcapsule/retrieve:


### PR DESCRIPTION
### 추가사항
multer.js
```
// 코드 중복 방지
const s3Client = new AWS.S3();
export const uploadImageToS3 = async (base64Image) => {
	// 이미지 타입 추출 (예: 'image/png')
	const imageType = base64Image.match(/data:(.*);base64,/)[1];

	// base64 인코딩 부분만 추출
	// base64 데이터의 헤더 부분을 제거한 후 Buffer.from 함수에 전달
	const base64Data = base64Image.replace(/^data:image\/\w+;base64,/, "");

	const buffer = Buffer.from(base64Data, "base64");

	// 확장자 추출 (예: 'png')
	const extension = imageType.split("/")[1];

	const fileName = `images/${Date.now().toString()}.${extension}`; // 파일명 설정

	const data = {
		Bucket: process.env.S3_BUCKET_NAME,
		Key: fileName,
		Body: buffer,
		ContentEncoding: "base64",
		ContentType: imageType,
		ACL: "public-read",
	};

	try {
		const response = await s3Client.upload(data).promise();
		// console.log("esponse.Location: ", response.Location);
		return response.Location; // 업로드된 이미지의 URL을 반환
	} catch (error) {
		console.log("uploadImageToS3 err : ", error);
	}
};
```

### 변경사항
Controller.js
uploadImageToS3 함수 이용해서 업로드 된 url 가져오도록 수정
```
else if (value.type === "image") {
				const imageUrl = await uploadImageToS3(value.content);

				textImageId = await saveTextImage(
					connection,
					pcapsuleId,
					null,
					imageUrl,
					align_type,
				);
			}
```
**DB**
![image](https://github.com/REmemory-team/REmemory-Nodejs/assets/65389677/13574967-ff29-4e90-9b67-464df8040fc8)
**스웨거**
![image](https://github.com/REmemory-team/REmemory-Nodejs/assets/65389677/16bea478-247a-4b6e-96b6-38ce1ffdc1fa)

### 필요 개선 사항
swagger password string 으로 바꿨는데 비밀번호 틀렸다는 로그 -> 처리하기