### PR TITLE
♻️ [Refactor] rcapsule/create/text_image API 

### DIFF
--- a/src/app/Rcapsule/rcapsuleController.js
+++ b/src/app/Rcapsule/rcapsuleController.js
@@ -10,6 +10,7 @@ import {
 	addVoiceLetter_s,
 	readRcs_s,
 	readDetailRcs_s,
+	addTextImage_rcs,
 } from "./rcapsuleService.js";
 
 import { getUserInfos } from "../User/userProvider.js";
@@ -178,22 +179,18 @@ export const createText_c = async (req, res, next) => {
 	try {
 		//aws s3에 업로드 된 파일 url 접근 및 db 저장
 		//console.log(req.file.locatiron); // aws s3에 올려진 파일 url
-		console.log("글/사진 params", req.params); // -> { rcapsule_number: 'TEST_111111' }
-		console.log("글/사진 쿼리스트링", req.url); //-> 파싱 필요 /text_photo/TEST_111111?from_name=nahy&content_type=2&theme=1
-		console.log("글/사진 req.file", req.file); //req.file.location
-		console.log("req.body.text : ", req.body.text); // -> text 그대로 잘 담김
+		// console.log("글/사진 params", req.params); // -> { rcapsule_number: 'TEST_111111' }
+		// console.log("글/사진 쿼리스트링", req.url); //-> 파싱 필요 /text_photo/TEST_111111?from_name=nahy&content_type=2&theme=1
+		// console.log("글/사진 req.file", req.file); //req.file.location
+		// console.log("req.body.text : ", req.body.text); // -> text 그대로 잘 담김
 
-		const paramsRegex = /from_name=(.*?)&content_type=(.*)/;
-		const [, from_name, content_type] = paramsRegex.exec(req.url);
-		// const image_url = req.file.location;
-		console.log("from_name 확인:", from_name);
-		console.log("content_type 확인:", content_type);
+		// const paramsRegex = /from_name=(.*?)&content_type=(.*)/;
+		// const [, from_name, content_type] = paramsRegex.exec(req.url);
 
-		const body = {
-			from_name: from_name,
-			content_type: content_type,
-			text: req.body.text,
-		};
+		const capsule_number = req.body.capsule_number;
+		const textImageContent = req.body.contents;
+		const align_type = req.body.align_type;
+		const from_name = req.body.from_name; // rcapsule 글/사진 쓰기의 경우 이게 필요
 
 		// if (!req.file.location) {
 		//    return res.status(500).send(
@@ -201,56 +198,42 @@ export const createText_c = async (req, res, next) => {
 		//    );
 		// }
 
-		if (!req.params.rcapsule_number) {
-			return res
-				.status(400)
-				.send(
-					response(status.BAD_REQUEST, { err: "rcapsule_number가 없습니다." }),
-				);
-		}
+		// if (!req.params.rcapsule_number) {
+		// 	return res
+		// 		.status(400)
+		// 		.send(
+		// 			response(status.BAD_REQUEST, { err: "rcapsule_number가 없습니다." }),
+		// 		);
+		// }
 
 		// 글 , 사진 둘 다 없을 경우만
-		if (!req.body.text && !req.fil.location) {
-			return res
-				.status(400)
-				.send(
-					response(status.BAD_REQUEST, { err: "capsule의 내용이 없습니다." }),
-				);
-		}
+		// if (!req.body.text && !req.fil.location) {
+		// 	return res
+		// 		.status(400)
+		// 		.send(
+		// 			response(status.BAD_REQUEST, { err: "capsule의 내용이 없습니다." }),
+		// 		);
+		// }
 
-		//형식적 validation 처리 *이 부분 추가 수정하기
-		// if (!req.params.rcapsule_number) {
-		//    return res.send(response(status.BAD_REQUEST));
-		// }
-		// if (!from_name) {
-		//    return res.send(response(status.NOT_FOUND));
-		// } else if (!content_type) {
-		//    return res.send(response(status.NOT_FOUND));
-		// } else if (!image_url && !body) {
-		//    return res.send(response(status.NOT_FOUND));
-		// }
 		//처리 결과를 클라이언트에게 응답
-		const result = await createText_s(
-			req.file.location,
-			req.params.rcapsule_number,
-			body,
-		);
-
-		res.send(result);
-
-		// res.status(200).send(
-		//    response(status.SUCCESS, {
-		//       // ...req.body, // 원래의 데이터 복사
-		//       capsule_number: result.capsuleNumber,
-		//    }),
+		// const result = await createText_s(
+		// 	req.file.location,
+		// 	req.params.rcapsule_number,
+		// 	body,
 		// );
+
+		// res.send(result);
+
+		const result = await addTextImage_rcs(
+			capsule_number,
+			textImageContent,
+			align_type,
+			from_name,
+		);
+		res.status(200).send(response(status.SUCCESS, {
+			result,
+		}));
 	} catch (error) {
-		// * 추가
-		// res.send(status.INTERNAL_SERVER_ERROR, {
-		//    error: "텍스트 및 사진 파일 업로드 실패.",
-		//    detail: error,
-		// });
-		// next(error);
 		console.log(error.data);
 		// if (error.data.code == 'CAPSULE4001') {
 		//    res.status(400).send(response(status.CAPSULE_NOT_FOUND, {error: "존재하지 않는 롤링페이퍼 캡슐입니다."}))
@@ -362,21 +345,21 @@ export const readRcs_c = async (req, res, next) => {
 };
 
 
-// // API Name : rcapsule 상세조회 API
-// // [GET] /retrieveDetail
-// export const readDetailRcs_c = async (req, res, next) => {
-//    try {
-//       const capsuleNumber = req.query.capsule_number;
-//       const capsulePassword = req.query.rcapsule_password;
+// API Name : rcapsule 상세조회 API
+// [GET] /retrieveDetail
+export const readDetailRcs_c = async (req, res, next) => {
+   try {
+      const capsuleNumber = req.query.capsule_number;
+      const capsulePassword = req.query.rcapsule_password;
 
-//       const data = await readDetailRcs_s(capsuleNumber, capsulePassword);
+      const data = await readDetailRcs_s(capsuleNumber, capsulePassword);
 
-//       res.send(
-//          response(status.SUCCESS, {
-//             pcapsules: data,
-//          }),
-//       );
-//    } catch (error) {
-//       next(error);
-//    }
-// };
+      res.send(
+         response(status.SUCCESS, {
+            pcapsules: data,
+         }),
+      );
+   } catch (error) {
+      next(error);
+   }
+};

--- a/src/app/Rcapsule/rcapsuleController.js
+++ b/src/app/Rcapsule/rcapsuleController.js
@@ -85,9 +85,6 @@ export const createRcapsule = async (req, res, next) => {
 		// const userId = req.user ? req.user.userId : null; //userId를 어떻게 가져올 수 있을까..?
 
 		console.log(req.url);
-		// const paramsRegex = /userId=(.*?)/; //swagger 테스트용 임시
-		// const [, userId] = paramsRegex.exec(req.url);
-		// console.log('userID : ', userId);
 		const paramsRegex = /[?&]userId=([^&]+)/;
 		const match = paramsRegex.exec(req.url);
 		const userId = match && decodeURIComponent(match[1]);
@@ -179,10 +176,6 @@ export const createText_c = async (req, res, next) => {
 	try {
 		//aws s3에 업로드 된 파일 url 접근 및 db 저장
 		//console.log(req.file.locatiron); // aws s3에 올려진 파일 url
-		// console.log("글/사진 params", req.params); // -> { rcapsule_number: 'TEST_111111' }
-		// console.log("글/사진 쿼리스트링", req.url); //-> 파싱 필요 /text_photo/TEST_111111?from_name=nahy&content_type=2&theme=1
-		// console.log("글/사진 req.file", req.file); //req.file.location
-		// console.log("req.body.text : ", req.body.text); // -> text 그대로 잘 담김
 
 		// const paramsRegex = /from_name=(.*?)&content_type=(.*)/;
 		// const [, from_name, content_type] = paramsRegex.exec(req.url);
@@ -192,20 +185,6 @@ export const createText_c = async (req, res, next) => {
 		const align_type = req.body.align_type;
 		const from_name = req.body.from_name; // rcapsule 글/사진 쓰기의 경우 이게 필요
 
-		// if (!req.file.location) {
-		//    return res.status(500).send(
-		//       response(status.INTERNAL_SERVER_ERROR, { err: "파일 업로드 실패." }),
-		//    );
-		// }
-
-		// if (!req.params.rcapsule_number) {
-		// 	return res
-		// 		.status(400)
-		// 		.send(
-		// 			response(status.BAD_REQUEST, { err: "rcapsule_number가 없습니다." }),
-		// 		);
-		// }
-
 		// 글 , 사진 둘 다 없을 경우만
 		// if (!req.body.text && !req.fil.location) {
 		// 	return res
@@ -214,16 +193,7 @@ export const createText_c = async (req, res, next) => {
 		// 			response(status.BAD_REQUEST, { err: "capsule의 내용이 없습니다." }),
 		// 		);
 		// }
-
-		//처리 결과를 클라이언트에게 응답
-		// const result = await createText_s(
-		// 	req.file.location,
-		// 	req.params.rcapsule_number,
-		// 	body,
-		// );
-
-		// res.send(result);
-
+		
 		const result = await addTextImage_rcs(
 			capsule_number,
 			textImageContent,

--- a/src/app/Rcapsule/rcapsuleDao.js
+++ b/src/app/Rcapsule/rcapsuleDao.js
@@ -55,25 +55,6 @@ VALUES (null, null, ?, ?, ?, ?, ?);`;
 	return result[0];
 };
 
-//theme이 왜 안 들어가 있는지..? -> 보류
-// export const setRcapsuleWriter = async (
-//    connection,
-//    rcapsule_id,
-//    from_name,
-//    content_type,
-// ) => {
-//    const query = `INSERT INTO rcapsule_writer (id, rcapsule_id, from_name, content_type, created_at, updated_at)
-// VALUES (null, ?, ?, ?, ?);`;
-//    const [result] = await connection.query(query, [
-//       rcapsule_id,
-//       from_name,
-//       content_type,
-//       new Date(),
-//       new Date(),
-//    ]);
-//    return result[0];
-// };
-
 export const insertTimeCapsule = async (connection, capsule_number, userId) => {
 	const query = `INSERT INTO time_capsule (id, member_id, total_cnt, capsule_number) VALUES (NULL, ?, 0, ?);`;
 	const [insertTimeCapsuleRow] = await connection.query(query, [
@@ -141,8 +122,7 @@ VALUES (null, ?, ?, ?, ?, ?);`;
 		new Date(),
 		new Date(),
 	]);
-	console.log("setRcapsuleWriter_n : ", result[0]);
-	return result[0];
+	return result.insertId;
 };
 
 export const addVoiceLetter_d = async (connection, voiceUrl, writer_id) => {
@@ -217,3 +197,22 @@ export const retrieveCapsule_d = async (connection, capsule_number) => {
 	const [retrieveCapsuleRow] = await connection.query(query, capsule_number);
 	return retrieveCapsuleRow[0];
 };
+
+export const saveTextImage_rcs = async (
+	connection,
+	rwcapsule_id,
+	body,
+	image_url,
+	align_type,
+) => {
+	const query = `INSERT INTO text_image (rwcapsule_id, body, image_url, align_type, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?);`;
+	const [result] = await connection.query(query, [
+		rwcapsule_id,
+		body,
+		image_url,
+		align_type,
+		new Date(),
+		new Date(),
+	]);
+	return result.insertId;
+}

--- a/src/app/Rcapsule/rcapsuleRoute.js
+++ b/src/app/Rcapsule/rcapsuleRoute.js
@@ -12,6 +12,7 @@ import {
 	readRcs_c,
 	readRcs,
 } from "./rcapsuleController.js";
+import { readDetailRcs_s } from "./rcapsuleService.js";
 
 export const rcapsuleRouter = express.Router();
 
@@ -36,9 +37,11 @@ rcapsuleRouter.get("/url_info/:rcapsule_number", asyncHandler(readDear_c));
 
 //글&사진 쓰기
 rcapsuleRouter.post(
-	"/text_photo/:rcapsule_number",
-	upload.single("photo_rcapsule"),
+	"/create/text_image",
+	// upload.single("photo_rcapsule"),
 	asyncHandler(createText_c),
 );
 
 rcapsuleRouter.get("/retrieve", asyncHandler(readRcs_c));
+
+// rcapsuleRouter.get("/retrieveDetail", asyncHandler(readDetailRcs_s));

--- a/src/app/Rcapsule/rcapsuleService.js
+++ b/src/app/Rcapsule/rcapsuleService.js
@@ -101,56 +101,57 @@ export const readDear_s = async (capsuleNumber) => {
 };
 
 //post textNphotos * photo 파일 변환하기 * error
-export const createText_s = async (imageurl, capsule_number, body) => {
-	const connection = await pool.getConnection(async (conn) => conn);
-	// const { from_name, content_type, theme, text } = body;
-	const { from_name, content_type, text } = body;
+// export const createText_s = async (imageurl, capsule_number, body) => {
+// 	const connection = await pool.getConnection(async (conn) => conn);
+// 	// const { from_name, content_type, theme, text } = body;
+// 	const { from_name, content_type, text } = body;
 
-	const requiredFields = ["from_name", "content_type"];
+// 	const requiredFields = ["from_name", "content_type"];
 
-	requiredFields.forEach((field) => {
-		if (!body.hasOwnProperty(field)) {
-			throw new Error(`Missing required filed: ${field}`);
-		}
-	});
+// 	requiredFields.forEach((field) => {
+// 		if (!body.hasOwnProperty(field)) {
+// 			throw new Error(`Missing required filed: ${field}`);
+// 		}
+// 	});
 
-	const check_rcapsule = await checkRcapsule_d(connection, capsule_number);
+// 	const check_rcapsule = await checkRcapsule_d(connection, capsule_number);
 
-	if (!check_rcapsule) {
-		throw new BaseError(status.CAPSULE_NOT_FOUND);
-	}
+// 	if (!check_rcapsule) {
+// 		throw new BaseError(status.CAPSULE_NOT_FOUND);
+// 	}
 
-	try {
-		connection.beginTransaction();
+// 	try {
+// 		connection.beginTransaction();
 
-		const rcapsule_id = await getRcapsuleId(connection, capsule_number);
+// 		const rcapsule_id = await getRcapsuleId(connection, capsule_number);
 
-		// await setRcapsuleWriter(connection, rcapsule_id, from_name, content_type);
-		await setRcapsuleWriter_n(connection, rcapsule_id, from_name, content_type);
+// 		// await setRcapsuleWriter(connection, rcapsule_id, from_name, content_type);
+// 		await setRcapsuleWriter_n(connection, rcapsule_id, from_name, content_type);
 
-		const writer_id = await getWriterId(connection, rcapsule_id);
-		console.log("writer_id : ", writer_id);
+// 		const writer_id = await getWriterId(connection, rcapsule_id);
+// 		console.log("writer_id : ", writer_id);
 
-		await addTextImage_d(connection, imageurl, writer_id, text);
+// 		await addTextImage_d(connection, imageurl, writer_id, text);
 
-		await connection.commit();
+// 		await connection.commit();
 
-		// res.send(
-		//    response(status.SUCCESS, {
-		//       data: rCapsuleData,
-		//    }),
-		// );
-		return response(status.SUCCESS);
-	} catch (error) {
-		//에러 발생 시 롤백
-		await connection.rollback();
-		throw error;
-	} finally {
-		//모든 경우에 연결 반환
-		connection.release();
-	}
-};
+// 		// res.send(
+// 		//    response(status.SUCCESS, {
+// 		//       data: rCapsuleData,
+// 		//    }),
+// 		// );
+// 		return response(status.SUCCESS);
+// 	} catch (error) {
+// 		//에러 발생 시 롤백
+// 		await connection.rollback();
+// 		throw error;
+// 	} finally {
+// 		//모든 경우에 연결 반환
+// 		connection.release();
+// 	}
+// };
 
+// **수정된 글/사진 쓰기 로직**
 export const addTextImage_rcs = async (capsule_number, textImageContent, align_type, from_name) => {
 	const connection = await pool.getConnection(async (conn) => conn);
 

--- a/swagger/rememorySwagger.yaml
+++ b/swagger/rememorySwagger.yaml
@@ -1035,52 +1035,150 @@ paths:
                     type: string
                     example: "Internal Server Error. 관리자에게 문의하세요."
   # [POST] 롤링페이퍼 글/사진 메세지 추가
-  /rcapsule/text_photo/{rcapsule_number}:
+  # /rcapsule/text_photo/{rcapsule_number}:
+  #   post:
+  #     tags:
+  #       - Rcapsule
+  #     summary: "롤링페이퍼에 글/사진 메세지 쓰기"
+  #     consumes:
+  #       - multipart/form-data
+  #       - application/json
+  #       - x-www-form-urlencoded
+  #     parameters:
+  #       - in: path
+  #         name: rcapsule_number
+  #         # required: true
+  #         description: 글/사진 메세지를 쓰고 싶은 롤링페이퍼 고유번호
+  #         schema:
+  #           type: string
+  #           example: "testMember1_41305"
+  #       - in: query
+  #         name: from_name
+  #         # required: true
+  #         description: 작성한 사람
+  #         schema:
+  #           type: string
+  #           example: "test"
+  #       - in: query
+  #         name: content_type
+  #         # required: true
+  #         schema:
+  #           type: integer
+  #           example: 1
+  #       - in: formData
+  #         name: text
+  #         schema:
+  #           type: string
+  #           example: "생일 축하해 ~~ ~~~~~~~~~~~"
+  #       - in: formData
+  #         name: photo_rcapsule
+  #         type: file
+  #         description: file to upload
+  #     responses:
+  #       "200":
+  #         description: success
+  #         content:
+  #           application/json:
+  #             schema:
+  #               type: object
+  #               properties:
+  #                 status:
+  #                   type: integer
+  #                   example: 200
+  #                 isSuccess:
+  #                   type: boolean
+  #                   example: true
+  #                 code:
+  #                   type: integer
+  #                   example: 2000
+  #                 message:
+  #                   type: string
+  #                   example: "success!"
+  #       "400":
+  #         description: Bad Request
+  #         content:
+  #           application/json:
+  #             schema:
+  #               type: object
+  #               properties:
+  #                 status:
+  #                   type: integer
+  #                   example: 400
+  #                 isSuccess:
+  #                   type: boolean
+  #                   example: false
+  #                 code:
+  #                   type: integer
+  #                   example: COMMON001
+  #                 message:
+  #                   type: string
+  #                   example: "Bad Request"
+  #       "500":
+  #         description: Internal Server Error
+  #         content:
+  #           application/json:
+  #             schema:
+  #               type: object
+  #               properties:
+  #                 status:
+  #                   type: integer
+  #                   example: 500
+  #                 isSuccess:
+  #                   type: boolean
+  #                   example: false
+  #                 code:
+  #                   type: integer
+  #                   example: COMMON000
+  #                 message:
+  #                   type: string
+  #                   example: "Internal Server Error. 관리자에게 문의하세요."
+  /rcapsule/create/text_image:
     post:
       tags:
         - Rcapsule
-      summary: "롤링페이퍼에 글/사진 메세지 쓰기"
-      consumes:
-        - multipart/form-data
-        - application/json
-        - x-www-form-urlencoded
+      summary: rcapsule 글/사진 전송 API
       parameters:
-        # - in: formData
-        #   name: voice_rcapsule
-        #   type: file
-        #   description: file to upload
-        - in: path
-          name: rcapsule_number
-          # required: true
-          description: 글/사진 메세지를 쓰고 싶은 롤링페이퍼 고유번호
+        - name: text_image
+          in: body
           schema:
-            type: string
-            example: "testMember1_41305"
-        - in: query
-          name: from_name
-          # required: true
-          description: 작성한 사람
-          schema:
-            type: string
-            example: "test"
-        - in: query
-          name: content_type
-          # required: true
-          schema:
-            type: integer
-            example: 1
-        - in: formData
-          name: text
-          schema:
-            type: string
-            example: "생일 축하해 ~~ ~~~~~~~~~~~"
-        - in: formData
-          name: photo_rcapsule
-          type: file
-          description: file to upload
+            type: object
+            properties:
+              capsule_number:
+                type: stirng
+                description: Caspule number
+                example: "testMember1_88919"
+              contents:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    conent:
+                      type: string
+                example:
+                  [
+                    { type: "text", content: "rcs test" },
+                    {
+                      type: "image",
+                      content: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMA…kakDsHxpPTEAbA/7800saP21M9FC5t1EGAAAAAElFTkSuQmCC",
+                    },
+                    {
+                      type: "image",
+                      content: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMA…kakDsHxpPTEAbA/7800saP21M9FC5t1EGAAAAAElFTkSuQmCC",
+                    },
+
+                    { type: "text", content: "rcs test 222?" },
+                  ]
+              align_type:
+                type: string
+                example: "left"
+              from_name:
+                type: string
+                example: "nahy"
       responses:
         "200":
-          description: success
+          description: 성공
           content:
             application/json:
               schema:
@@ -1136,6 +1234,8 @@ paths:
                   message:
                     type: string
                     example: "Internal Server Error. 관리자에게 문의하세요."
+
+
   # [POST] 롤링페이퍼 음성 메세지 추가
   /rcapsule/voice/{rcapsule_number}:
     post:


### PR DESCRIPTION
/rcapsule/text_photo/{rcapsule_number} -> /rcapsule/create/text_image로 pcapsule과 동일하게 변경

![image](https://github.com/REmemory-team/REmemory-Nodejs/assets/117283341/dd539a0d-3fa4-4730-93d8-9d7927c76176)

- rcapsule_writer 테이블에도 새로운 row를 생성해야 하므로 from_name 값을 추가로 받음

`		const rcapsuleId = await getRcapsuleId(connection, capsule_number);

		const writer_id = await setRcapsuleWriter_n(connection, rcapsuleId, from_name, 1); //글/사진의 경우 1

		console.log("writer_id : ", writer_id);

		let textImageId = null;

		for (let i = 0; i < textImageContent.length; i++) {
			const value = textImageContent[i];
			if (value.type === "text") {
				textImageId = await saveTextImage_rcs(
					connection,
					writer_id,
					value.content,
					null,
					align_type,
				);
			} else if (value.type === "image") {
				const imageUrl = await uploadImageToS3(value.content);

				textImageId = await saveTextImage_rcs(
					connection,
					writer_id,
					null,
					imageUrl,
					align_type,
				);
			}
			if (!textImageId) throw new BaseError(status.INTERNAL_SERVER_ERROR);
		}
`
- 다음과 같이 writer_id를 사용하여 saveTextImage_rcs 실행
- 이외의 로직은 pcapsule과 동일함


- swagger test 완료